### PR TITLE
Update fitz.go

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -222,8 +222,9 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (image.Image, error) {
 	if pixels == nil {
 		return nil, ErrPixmapSamples
 	}
+	defer C.free(unsafe.Pointer(pixels))
 
-	img.Pix = C.GoBytes(unsafe.Pointer(pixels), C.int(4*bbox.x1*bbox.y1))
+	img.Pix = C.GoBytes(, C.int(4*bbox.x1*bbox.y1))
 	img.Rect = image.Rect(int(bbox.x0), int(bbox.y0), int(bbox.x1), int(bbox.y1))
 	img.Stride = 4 * img.Rect.Max.X
 


### PR DESCRIPTION
fix memory leakage: free pixels pointer on defer