### PR TITLE
add ability to get links for a page

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -57,6 +57,10 @@ type Outline struct {
 	Top float64
 }
 
+type Link struct {
+	URI string
+}
+
 // New returns new fitz document.
 func New(filename string) (f *Document, err error) {
 	f = &Document{}
@@ -277,6 +281,31 @@ func (f *Document) ImagePNG(pageNumber int, dpi float64) ([]byte, error) {
 	str := C.GoStringN(C.fz_string_from_buffer(f.ctx, buf), C.int(size))
 
 	return []byte(str), nil
+}
+
+func (f *Document) Links(pageNumber int) ([]Link, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	if pageNumber >= f.NumPage() {
+		return nil, ErrPageMissing
+	}
+
+	page := C.fz_load_page(f.ctx, f.doc, C.int(pageNumber))
+	defer C.fz_drop_page(f.ctx, page)
+
+	links := C.fz_load_links(f.ctx, page)
+	defer C.fz_drop_link(f.ctx, links)
+
+	gLinks := make([]Link, 0)
+
+	for currLink := links; currLink != nil; currLink = currLink.next {
+		gLinks = append(gLinks, Link{
+			URI: C.GoString(currLink.uri),
+		})
+	}
+
+	return gLinks, nil
 }
 
 // Text returns text for given page number.

--- a/fitz.go
+++ b/fitz.go
@@ -297,12 +297,23 @@ func (f *Document) Links(pageNumber int) ([]Link, error) {
 	links := C.fz_load_links(f.ctx, page)
 	defer C.fz_drop_link(f.ctx, links)
 
-	gLinks := make([]Link, 0)
-
+	linkCount := 0
 	for currLink := links; currLink != nil; currLink = currLink.next {
-		gLinks = append(gLinks, Link{
+		linkCount++
+	}
+
+	if linkCount == 0 {
+		return nil, nil
+	}
+
+	gLinks := make([]Link, linkCount)
+
+	currLink := links
+	for i := 0; i < linkCount; i++ {
+		gLinks[i] = Link{
 			URI: C.GoString(currLink.uri),
-		})
+		}
+		currLink = currLink.next
 	}
 
 	return gLinks, nil

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -82,6 +82,28 @@ func TestImageFromMemory(t *testing.T) {
 	}
 }
 
+func TestLinks(t *testing.T) {
+	doc, err := New(filepath.Join("testdata", "test.pdf"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer doc.Close()
+
+	links, err := doc.Links(2)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if len(links) != 1 {
+		t.Error("expected 1 link, got", len(links))
+	}
+
+	if links[0].URI != "https://creativecommons.org/licenses/by-nc-sa/4.0/" {
+		t.Error("expected empty URI, got", links[0].URI)
+	}
+}
+
 func TestText(t *testing.T) {
 	doc, err := New(filepath.Join("testdata", "test.pdf"))
 	if err != nil {


### PR DESCRIPTION
`doc.Links(pageNum)` will return a slice of `Link`s present on the given page