### PR TITLE
Add ability to pull bounds from page

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -537,6 +537,23 @@ func (f *Document) Metadata() map[string]string {
 	return data
 }
 
+// Gives the Bounds of a given Page in the document.
+func (f *Document) Bound(pageNumber int) (image.Rectangle, error) {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	if pageNumber >= f.NumPage() {
+		return image.Rectangle{}, ErrPageMissing
+	}
+
+	page := C.fz_load_page(f.ctx, f.doc, C.int(pageNumber))
+	defer C.fz_drop_page(f.ctx, page)
+
+	var bounds C.fz_rect
+	bounds = C.fz_bound_page(f.ctx, page)
+	return image.Rect(int(bounds.x0), int(bounds.y0), int(bounds.x1), int(bounds.y1)), nil
+}
+
 // Close closes the underlying fitz document.
 func (f *Document) Close() error {
 	if f.stream != nil {

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -2,6 +2,7 @@ package fitz
 
 import (
 	"fmt"
+	"image"
 	"image/jpeg"
 	"io/ioutil"
 	"os"
@@ -228,5 +229,30 @@ func TestMetadata(t *testing.T) {
 	meta := doc.Metadata()
 	if len(meta) == 0 {
 		t.Error(fmt.Errorf("metadata is empty"))
+	}
+}
+
+func TestBound(t *testing.T) {
+	doc, err := New(filepath.Join("testdata", "test.pdf"))
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer doc.Close()
+	expected := image.Rect(0, 0, 612, 792)
+
+	for i := 0; i < doc.NumPage(); i++ {
+		bound, err := doc.Bound(i)
+		if err != nil {
+			t.Error(err)
+		}
+		if bound != expected {
+			t.Error(fmt.Errorf("bounds didn't match go %v when expedient %v", bound, expected))
+		}
+	}
+
+	_, err = doc.Bound(doc.NumPage())
+	if err != ErrPageMissing {
+		t.Error(fmt.Errorf("ErrPageMissing not returned got %v", err))
 	}
 }


### PR DESCRIPTION
I wanted to have the ability to pull the pdf bounds of the page before converting it over into a png. Sometimes the pages are quite large, depending on how they are generated. The bounds give the ability to guess a suitable dpi before doing the heavy work of converting it over into an image. 

I also though about creating another struct for `Page` since mupdf has its own struct we could pull more methods from but I thought this was the simplest for now since we didn't have to worry about sharing locks. 