### PR TITLE
enable drop_pixmap after use to reduce memory usage

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -225,7 +225,7 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (image.Image, error) {
 	}
 
 	C.fz_clear_pixmap_with_value(f.ctx, pixmap, C.int(0xff))
-	//defer C.fz_drop_pixmap(f.ctx, pixmap)
+	defer C.fz_drop_pixmap(f.ctx, pixmap)
 
 	device := C.fz_new_draw_device(f.ctx, ctm, pixmap)
 	C.fz_enable_device_hints(f.ctx, device, C.FZ_NO_CACHE)
@@ -277,7 +277,7 @@ func (f *Document) ImagePNG(pageNumber int, dpi float64) ([]byte, error) {
 	}
 
 	C.fz_clear_pixmap_with_value(f.ctx, pixmap, C.int(0xff))
-	//defer C.fz_drop_pixmap(f.ctx, pixmap)
+	defer C.fz_drop_pixmap(f.ctx, pixmap)
 
 	device := C.fz_new_draw_device(f.ctx, ctm, pixmap)
 	C.fz_enable_device_hints(f.ctx, device, C.FZ_NO_CACHE)

--- a/fitz.go
+++ b/fitz.go
@@ -225,7 +225,7 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (image.Image, error) {
 	}
 
 	C.fz_clear_pixmap_with_value(f.ctx, pixmap, C.int(0xff))
-	defer C.fz_drop_pixmap(f.ctx, pixmap)
+	//defer C.fz_drop_pixmap(f.ctx, pixmap)
 
 	device := C.fz_new_draw_device(f.ctx, ctm, pixmap)
 	C.fz_enable_device_hints(f.ctx, device, C.FZ_NO_CACHE)

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -25,6 +25,8 @@ func TestImage(t *testing.T) {
 		t.Error(err)
 	}
 
+	defer os.RemoveAll(tmpDir)
+
 	for n := 0; n < doc.NumPage(); n++ {
 		img, err := doc.Image(n)
 		if err != nil {
@@ -120,6 +122,8 @@ func TestText(t *testing.T) {
 		t.Error(err)
 	}
 
+	defer os.RemoveAll(tmpDir)
+
 	for n := 0; n < doc.NumPage(); n++ {
 		text, err := doc.Text(n)
 		if err != nil {
@@ -148,10 +152,12 @@ func TestHTML(t *testing.T) {
 
 	defer doc.Close()
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "fitz")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "fitz")
 	if err != nil {
 		t.Error(err)
 	}
+
+	defer os.RemoveAll(tmpDir)
 
 	for n := 0; n < doc.NumPage(); n++ {
 		html, err := doc.HTML(n, true)
@@ -173,6 +179,32 @@ func TestHTML(t *testing.T) {
 	}
 }
 
+func TestPNG(t *testing.T) {
+	doc, err := fitz.New(filepath.Join("testdata", "test.pdf"))
+	if err != nil {
+		t.Error(err)
+	}
+	
+	defer doc.Close()
+
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "fitz")
+	if err != nil {
+		t.Error(err)
+	}
+
+	defer os.RemoveAll(tmpDir)
+
+	for n := 0; n < doc.NumPage(); n++ {
+		png, err := doc.ImagePNG(n, 300.0)
+		if err != nil {
+			t.Error(err)
+		}
+		if err = os.WriteFile(filepath.Join(tmpDir, fmt.Sprintf("test%03d.png", n)), png, 0644); err != nil {
+			t.Error(err)
+		}
+	}
+}
+
 func TestSVG(t *testing.T) {
 	doc, err := fitz.New(filepath.Join("testdata", "test.pdf"))
 	if err != nil {
@@ -181,10 +213,12 @@ func TestSVG(t *testing.T) {
 
 	defer doc.Close()
 
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "fitz")
+	tmpDir, err := os.MkdirTemp(os.TempDir(), "fitz")
 	if err != nil {
 		t.Error(err)
 	}
+
+	defer os.RemoveAll(tmpDir)
 
 	for n := 0; n < doc.NumPage(); n++ {
 		svg, err := doc.SVG(n)

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"


### PR DESCRIPTION
Without this change pixmap allocation is held till GC, increasing memory usage, which adds up quickly with a large pdf with lots of pages

e.g.
alloc_space:
<img width="840" alt="Screenshot 2024-03-12 at 10 19 09 PM" src="https://github.com/gen2brain/go-fitz/assets/127804/76296db9-8988-48d8-a418-cb6b596e25d2">

isuse_space:
<img width="1670" alt="Screenshot 2024-03-12 at 10 19 36 PM" src="https://github.com/gen2brain/go-fitz/assets/127804/1c199666-1582-4df6-891c-498c4304a4d3">

