### PR TITLE
Fix: annotations not showing up in converted pages 

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/gen2brain/go-fitz"
+	"github.com/LegalForceLawRAPC/go-fitz"
 )
 
 func ExampleNew() {

--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -62,6 +62,16 @@ int run_page_contents(fz_context *ctx, fz_page *page, fz_device *dev, fz_matrix 
 
 	return 1;
 }
+
+int run_page(fz_context *ctx, fz_page *page, fz_device *dev, fz_matrix transform, fz_cookie *cookie) {
+	fz_try(ctx) {
+		fz_run_page(ctx, page, dev, transform, cookie);
+	}
+	fz_catch(ctx) {
+		return 0;
+	}
+	return 1;
+}
 */
 import "C"
 
@@ -231,7 +241,7 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (*image.RGBA, error) {
 	defer C.fz_drop_device(f.ctx, device)
 
 	drawMatrix := C.fz_identity
-	ret := C.run_page_contents(f.ctx, page, device, drawMatrix, nil)
+	ret := C.run_page(f.ctx, page, device, drawMatrix, nil)
 	if ret == 0 {
 		return nil, ErrRunPageContents
 	}
@@ -288,7 +298,7 @@ func (f *Document) ImagePNG(pageNumber int, dpi float64) ([]byte, error) {
 	defer C.fz_drop_device(f.ctx, device)
 
 	drawMatrix := C.fz_identity
-	ret := C.run_page_contents(f.ctx, page, device, drawMatrix, nil)
+	ret := C.run_page(f.ctx, page, device, drawMatrix, nil)
 	if ret == 0 {
 		return nil, ErrRunPageContents
 	}

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -10,7 +10,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/gen2brain/go-fitz"
+	"github.com/LegalForceLawRAPC/go-fitz"
 )
 
 func TestImage(t *testing.T) {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/gen2brain/go-fitz
+module github.com/LegalForceLawRAPC/go-fitz
 
 go 1.22
 


### PR DESCRIPTION
Hello
I was working on a pdf to image convertor and I noticed that annotation texts were not visible in the resulting images from the pdf.
I went through mupdf and found

https://github.com/ArtifexSoftware/mupdf/blob/8ea59588b1ed1045c9d5b961ccd68bd108e88e41/source/pdf/pdf-run.c#L421-L424
```c
pdf_run_page(fz_context *ctx, pdf_page *page, fz_device *dev, fz_matrix ctm, fz_cookie *cookie)
{
	pdf_run_page_with_usage(ctx, page, dev, ctm, "View", cookie);
}
```

which is supposed to convert pages along with other stuff like widgets and annotations.

So, I created this PR to add support for that