### PR TITLE
fix[issue #142]: SIGSEV during concurrent rendering of PDF in Image() or ImageDPI()

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ Go wrapper for [MuPDF](http://mupdf.com/) fitz library that can extract pages fr
 
 The bundled libraries are built without CJK fonts, if you need them you must use the external library.
 
-Calling e.g. Image() or Text() methods concurrently for the same document is not supported.
+Concurrent rendering is supported when each goroutine uses its own `Document` (MuPDF contexts are created with lock callbacks).
+Concurrency on the same `Document` is not supported: do not call methods (including `Close`) concurrently on one document instance.
 
 Purego implementation requires `libffi` and `libmupdf` shared libraries on runtime.
 You must set `fitz.FzVersion` in your code or set `FZ_VERSION` environment variable to exact version of the shared library. 

--- a/fitz.go
+++ b/fitz.go
@@ -7,6 +7,9 @@ import (
 	"unsafe"
 )
 
+// bytesPerPixelRGBA is the number of bytes per pixel in an RGBA pixmap (R, G, B, A).
+const bytesPerPixelRGBA = 4
+
 // Errors.
 var (
 	ErrNoSuchFile      = errors.New("fitz: no such file")
@@ -19,6 +22,7 @@ var (
 	ErrPageMissing     = errors.New("fitz: page missing")
 	ErrCreatePixmap    = errors.New("fitz: cannot create pixmap")
 	ErrPixmapSamples   = errors.New("fitz: cannot get pixmap samples")
+	ErrPixmapTooLarge  = errors.New("fitz: rendered page image too large")
 	ErrNeedsPassword   = errors.New("fitz: document needs password")
 	ErrLoadOutline     = errors.New("fitz: cannot load outline")
 )
@@ -47,6 +51,18 @@ type Outline struct {
 // Link type.
 type Link struct {
 	URI string
+}
+
+// pixmapSampleBytes returns the byte length of a tight-packed RGBA pixmap sample buffer.
+func pixmapSampleBytes(width, height int) (int, error) {
+	if width <= 0 || height <= 0 {
+		return 0, ErrCreatePixmap
+	}
+	n := int64(bytesPerPixelRGBA) * int64(width) * int64(height)
+	if n > int64(int(^uint(0)>>1)) || n > int64(1<<31-1) {
+		return 0, ErrPixmapTooLarge
+	}
+	return int(n), nil
 }
 
 func bytePtrToString(p *byte) string {

--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -363,8 +363,15 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (*image.RGBA, error) {
 		return nil, ErrPixmapSamples
 	}
 
+	width := int(bbox.x1) - int(bbox.x0)
+	height := int(bbox.y1) - int(bbox.y0)
+	n, err := pixmapSampleBytes(width, height)
+	if err != nil {
+		return nil, err
+	}
+
 	img := image.NewRGBA(image.Rect(int(bbox.x0), int(bbox.y0), int(bbox.x1), int(bbox.y1)))
-	copy(img.Pix, C.GoBytes(unsafe.Pointer(pixels), C.int(4*bbox.x1*bbox.y1)))
+	copy(img.Pix, C.GoBytes(unsafe.Pointer(pixels), C.int(n)))
 
 	return img, nil
 }

--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -5,6 +5,11 @@ package fitz
 /*
 #include <mupdf/fitz.h>
 #include <stdlib.h>
+#if defined(_WIN32)
+#include <windows.h>
+#else
+#include <pthread.h>
+#endif
 
 const char *fz_version = FZ_VERSION;
 #if defined(_WIN32)
@@ -12,6 +17,91 @@ const char *fz_version = FZ_VERSION;
 #else
 	typedef unsigned long store;
 #endif
+
+typedef struct go_fitz_locks {
+#if defined(_WIN32)
+	CRITICAL_SECTION mutex[FZ_LOCK_MAX];
+#else
+	pthread_mutex_t mutex[FZ_LOCK_MAX];
+#endif
+	fz_locks_context ctx;
+} go_fitz_locks;
+
+static go_fitz_locks go_fitz_global_locks;
+#if defined(_WIN32)
+static INIT_ONCE go_fitz_once = INIT_ONCE_STATIC_INIT;
+static int go_fitz_locks_ready = 0;
+#else
+static pthread_once_t go_fitz_once = PTHREAD_ONCE_INIT;
+static int go_fitz_locks_ready = 0;
+#endif
+
+static void go_fitz_lock(void *user, int lock) {
+	go_fitz_locks *locks = (go_fitz_locks *)user;
+#if defined(_WIN32)
+	EnterCriticalSection(&locks->mutex[lock]);
+#else
+	pthread_mutex_lock(&locks->mutex[lock]);
+#endif
+}
+
+static void go_fitz_unlock(void *user, int lock) {
+	go_fitz_locks *locks = (go_fitz_locks *)user;
+#if defined(_WIN32)
+	LeaveCriticalSection(&locks->mutex[lock]);
+#else
+	pthread_mutex_unlock(&locks->mutex[lock]);
+#endif
+}
+
+static void go_fitz_locks_init_impl(void) {
+	int i;
+
+	for (i = 0; i < FZ_LOCK_MAX; i++) {
+#if defined(_WIN32)
+		InitializeCriticalSection(&go_fitz_global_locks.mutex[i]);
+#else
+		if (pthread_mutex_init(&go_fitz_global_locks.mutex[i], NULL) != 0) {
+			while (--i >= 0) {
+				pthread_mutex_destroy(&go_fitz_global_locks.mutex[i]);
+			}
+			go_fitz_locks_ready = 0;
+			return;
+		}
+#endif
+	}
+
+	go_fitz_global_locks.ctx.user = &go_fitz_global_locks;
+	go_fitz_global_locks.ctx.lock = go_fitz_lock;
+	go_fitz_global_locks.ctx.unlock = go_fitz_unlock;
+	go_fitz_locks_ready = 1;
+}
+
+#if defined(_WIN32)
+static BOOL CALLBACK go_fitz_locks_once(PINIT_ONCE InitOnce, PVOID Parameter, PVOID *Context) {
+	go_fitz_locks_init_impl();
+	return go_fitz_locks_ready ? TRUE : FALSE;
+}
+#else
+static void go_fitz_locks_once(void) {
+	go_fitz_locks_init_impl();
+}
+#endif
+
+const fz_locks_context *go_fitz_locks_context(void) {
+#if defined(_WIN32)
+	if (!InitOnceExecuteOnce(&go_fitz_once, go_fitz_locks_once, NULL, NULL)) {
+		return NULL;
+	}
+#else
+	pthread_once(&go_fitz_once, go_fitz_locks_once);
+#endif
+	if (!go_fitz_locks_ready) {
+		return NULL;
+	}
+
+	return &go_fitz_global_locks.ctx;
+}
 
 fz_document *open_document(fz_context *ctx, const char *filename) {
 	fz_document *doc;
@@ -75,17 +165,36 @@ import (
 )
 
 // Document represents fitz document.
+// Methods on the same Document are not safe for concurrent use.
+// In particular, Close must not race with any other method.
 type Document struct {
 	ctx    *C.struct_fz_context
-	data   []byte // binds data to the Document lifecycle avoiding premature GC
+	cdata  unsafe.Pointer
 	doc    *C.struct_fz_document
 	mtx    sync.Mutex
 	stream *C.fz_stream
 }
 
+func (f *Document) initContext() error {
+	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, C.go_fitz_locks_context(), C.store(MaxStore), C.fz_version)))
+	if f.ctx == nil {
+		return ErrCreateContext
+	}
+
+	C.fz_register_document_handlers(f.ctx)
+
+	return nil
+}
+
 // New returns new fitz document.
 func New(filename string) (f *Document, err error) {
 	f = &Document{}
+	defer func() {
+		if err != nil && f != nil {
+			_ = f.Close()
+			f = nil
+		}
+	}()
 
 	filename, err = filepath.Abs(filename)
 	if err != nil {
@@ -97,13 +206,9 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
-	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.store(MaxStore), C.fz_version)))
-	if f.ctx == nil {
-		err = ErrCreateContext
+	if err = f.initContext(); err != nil {
 		return
 	}
-
-	C.fz_register_document_handlers(f.ctx)
 
 	cfilename := C.CString(filename)
 	defer C.free(unsafe.Pointer(cfilename))
@@ -129,16 +234,31 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 		return nil, ErrEmptyBytes
 	}
 	f = &Document{}
+	defer func() {
+		if err != nil && f != nil {
+			_ = f.Close()
+			f = nil
+		}
+	}()
 
-	f.ctx = (*C.struct_fz_context)(unsafe.Pointer(C.fz_new_context_imp(nil, nil, C.store(MaxStore), C.fz_version)))
-	if f.ctx == nil {
-		err = ErrCreateContext
+	if err = f.initContext(); err != nil {
 		return
 	}
 
-	C.fz_register_document_handlers(f.ctx)
+	f.cdata = C.CBytes(b)
+	if f.cdata == nil {
+		err = ErrOpenMemory
+		return
+	}
 
-	f.stream = C.fz_open_memory(f.ctx, (*C.uchar)(&b[0]), C.size_t(len(b)))
+	stream := C.fz_open_memory(f.ctx, (*C.uchar)(f.cdata), C.size_t(len(b)))
+	if stream == nil {
+		err = ErrOpenMemory
+		return
+	}
+
+	f.stream = C.fz_keep_stream(f.ctx, stream)
+	C.fz_drop_stream(f.ctx, stream)
 	if f.stream == nil {
 		err = ErrOpenMemory
 		return
@@ -150,14 +270,13 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 		return
 	}
 
-	f.data = b
-
 	cmagic := C.CString(magic)
 	defer C.free(unsafe.Pointer(cmagic))
 
 	f.doc = C.open_document_with_stream(f.ctx, cmagic, f.stream)
 	if f.doc == nil {
 		err = ErrOpenDocument
+		return
 	}
 
 	ret := C.fz_needs_password(f.ctx, f.doc)
@@ -183,6 +302,7 @@ func NewFromReader(r io.Reader) (f *Document, err error) {
 }
 
 // NumPage returns total number of pages in document.
+// This method is intentionally lock-free; callers must not race it with Close.
 func (f *Document) NumPage() int {
 	return int(C.fz_count_pages(f.ctx, f.doc))
 }
@@ -502,6 +622,7 @@ func (f *Document) SVG(pageNumber int) (string, error) {
 }
 
 // ToC returns the table of contents (also known as outline).
+// This method is intentionally lock-free; callers must not race it with Close.
 func (f *Document) ToC() ([]Outline, error) {
 	data := make([]Outline, 0)
 
@@ -535,6 +656,7 @@ func (f *Document) ToC() ([]Outline, error) {
 }
 
 // Metadata returns the map with standard metadata.
+// This method is intentionally lock-free; callers must not race it with Close.
 func (f *Document) Metadata() map[string]string {
 	data := make(map[string]string)
 
@@ -585,15 +707,30 @@ func (f *Document) Bound(pageNumber int) (image.Rectangle, error) {
 }
 
 // Close closes the underlying fitz document.
+// Close must not be called concurrently with other Document methods.
 func (f *Document) Close() error {
-	if f.stream != nil {
+	f.mtx.Lock()
+	defer f.mtx.Unlock()
+
+	if f.stream != nil && f.ctx != nil {
 		C.fz_drop_stream(f.ctx, f.stream)
+		f.stream = nil
 	}
 
-	C.fz_drop_document(f.ctx, f.doc)
-	C.fz_drop_context(f.ctx)
+	if f.doc != nil && f.ctx != nil {
+		C.fz_drop_document(f.ctx, f.doc)
+		f.doc = nil
+	}
 
-	f.data = nil
+	if f.ctx != nil {
+		C.fz_drop_context(f.ctx)
+		f.ctx = nil
+	}
+
+	if f.cdata != nil {
+		C.free(f.cdata)
+		f.cdata = nil
+	}
 
 	return nil
 }

--- a/fitz_concurrency_test.go
+++ b/fitz_concurrency_test.go
@@ -1,0 +1,103 @@
+//go:build cgo && !nocgo
+
+package fitz_test
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"syscall"
+	"testing"
+
+	"github.com/gen2brain/go-fitz"
+)
+
+const (
+	stressWorkers    = 8
+	stressIterations = 20
+)
+
+func runConcurrentImageDPIStress(t *testing.T) {
+	t.Helper()
+
+	pdfBytes, err := os.ReadFile(filepath.Join("testdata", "concurrency.pdf"))
+	if err != nil {
+		t.Fatalf("you need to provide a concurrency.pdf: %v", err)
+	}
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, stressWorkers)
+
+	for worker := 0; worker < stressWorkers; worker++ {
+		wg.Add(1)
+		go func(worker int) {
+			defer wg.Done()
+
+			for iter := 0; iter < stressIterations; iter++ {
+				doc, err := fitz.NewFromMemory(pdfBytes)
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d iteration %d open doc: %w", worker, iter, err)
+					return
+				}
+
+				page := iter % doc.NumPage()
+				img, err := doc.ImageDPI(page, 144)
+				closeErr := doc.Close()
+				if err != nil {
+					errCh <- fmt.Errorf("worker %d iteration %d render: %w", worker, iter, err)
+					return
+				}
+				if closeErr != nil {
+					errCh <- fmt.Errorf("worker %d iteration %d close: %w", worker, iter, closeErr)
+					return
+				}
+				if img == nil {
+					errCh <- fmt.Errorf("worker %d iteration %d render: nil image", worker, iter)
+					return
+				}
+			}
+		}(worker)
+	}
+
+	wg.Wait()
+	close(errCh)
+
+	for err := range errCh {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestConcurrentImageDPIStress(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skip stress test in short mode")
+	}
+
+	runConcurrentImageDPIStress(t)
+}
+
+func TestConcurrentImageDPISubprocessNoSegv(t *testing.T) {
+	if os.Getenv("GOFITZ_CONCURRENCY_CHILD") == "1" {
+		runConcurrentImageDPIStress(t)
+		return
+	}
+
+	cmd := exec.Command(os.Args[0], "-test.run", "^TestConcurrentImageDPISubprocessNoSegv$")
+	cmd.Env = append(os.Environ(), "GOFITZ_CONCURRENCY_CHILD=1")
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return
+	}
+
+	if exitErr, ok := err.(*exec.ExitError); ok {
+		if status, ok := exitErr.Sys().(syscall.WaitStatus); ok && status.Signaled() {
+			t.Fatalf("child process terminated by signal %s\n%s", status.Signal(), output)
+		}
+	}
+
+	t.Fatalf("child process failed: %v\n%s", err, output)
+}

--- a/fitz_nocgo.go
+++ b/fitz_nocgo.go
@@ -175,8 +175,15 @@ func (f *Document) ImageDPI(pageNumber int, dpi float64) (*image.RGBA, error) {
 		return nil, ErrPixmapSamples
 	}
 
+	width := int(bbox.X1) - int(bbox.X0)
+	height := int(bbox.Y1) - int(bbox.Y0)
+	n, err := pixmapSampleBytes(width, height)
+	if err != nil {
+		return nil, err
+	}
+
 	img := image.NewRGBA(image.Rect(int(bbox.X0), int(bbox.Y0), int(bbox.X1), int(bbox.Y1)))
-	copy(img.Pix, unsafe.Slice(pixels, 4*bbox.X1*bbox.Y1))
+	copy(img.Pix, unsafe.Slice(pixels, n))
 
 	return img, nil
 }


### PR DESCRIPTION
## Summary

This PR fixes intermittent SIGSEGVs during concurrent rendering by adding proper MuPDF lock wiring during context creation and tightening resource lifetimes in the cgo path.

Root cause: `fz_new_context_imp` was called with `nil` lock callbacks, which violates MuPDF’s multithreading contract when rendering overlaps across contexts/goroutines.

## What changed

- Added MuPDF lock callbacks (`fz_locks_context`) in cgo:
  - Implemented `lock/unlock` callbacks and `FZ_LOCK_MAX` mutex array.
  - Initialized once per process and shared by all contexts.
  - Passed lock context into `fz_new_context_imp(...)` for every `Document`.

- Hardened context/document lifecycle:
  - Centralized context creation in shared init path.
  - Added constructor cleanup on partial failures.
  - Made `Close()` cleanup ordering explicit and defensive (`stream -> doc -> context -> C buffer`).

- Fixed `NewFromMemory` lifetime hazards:
  - Switched to C-owned byte buffer (`C.CBytes`) instead of relying on Go slice memory.
  - Kept stream reference with `fz_keep_stream` and released temporary stream ref.
  - Freed C buffer on `Close()`.

- Added/updated documentation:
  - README now clearly states:
    - parallel rendering is supported across separate `Document` instances,
    - concurrency on the same `Document` (including racing with `Close`) is not supported.
  - Added code comments in `fitz_cgo.go` documenting same-document concurrency limits and lock-free method expectations.

## Why this fixes the crash

MuPDF requires caller-provided locks for safe multithreaded use. With lock callbacks registered, internal shared paths (alloc/glyph/freetype and related global state) are synchronized correctly across concurrent rendering workloads, preventing unsafe overlap that could lead to SIGSEGV.

## Compatibility

- Existing call sites (`New`, `NewFromMemory`, `NewFromReader`, `ImageDPI`, etc.) continue to work unchanged.

## Tests

- Added a test file to verify the fix
- You need to provide your own `concurrency.pdf` file for the test to work. I could not share the one I used as it contains sensitive data (it is an artifact from my app production environment)

## Notes

- This PR intentionally does **not** add same-document concurrent access support.
- Callers should continue using one `Document` per worker/goroutine for parallel conversion workflows.
