### PR TITLE
Silence MuPDF warnings/errors unconditionally (fixes #132)

### DIFF
--- a/fitz.go
+++ b/fitz.go
@@ -26,6 +26,19 @@ var (
 // MaxStore is maximum size in bytes of the resource store, before it will start evicting cached resources such as fonts and images.
 var MaxStore = 256 << 20
 
+// Quiet silences MuPDF warning and error output on Documents created while
+// this is true. When enabled, no-op callbacks are installed on each new
+// Document's fitz context, so MuPDF neither writes warnings/errors to
+// stderr nor invokes any default handler. Errors are still surfaced to
+// callers via Go error returns.
+//
+// Quiet is read when a Document is created; changing it does not affect
+// Documents that are already open. It is the caller's responsibility to
+// synchronize writes if Documents are created concurrently.
+//
+// This addresses issue #132.
+var Quiet bool
+
 // FzVersion is used for experimental purego implementation, it must be exactly the same as libmupdf shared library version.
 // It is also possible to set `FZ_VERSION` environment variable.
 var FzVersion = "1.24.9"

--- a/fitz.go
+++ b/fitz.go
@@ -26,19 +26,6 @@ var (
 // MaxStore is maximum size in bytes of the resource store, before it will start evicting cached resources such as fonts and images.
 var MaxStore = 256 << 20
 
-// Quiet silences MuPDF warning and error output on Documents created while
-// this is true. When enabled, no-op callbacks are installed on each new
-// Document's fitz context, so MuPDF neither writes warnings/errors to
-// stderr nor invokes any default handler. Errors are still surfaced to
-// callers via Go error returns.
-//
-// Quiet is read when a Document is created; changing it does not affect
-// Documents that are already open. It is the caller's responsibility to
-// synchronize writes if Documents are created concurrently.
-//
-// This addresses issue #132.
-var Quiet bool
-
 // FzVersion is used for experimental purego implementation, it must be exactly the same as libmupdf shared library version.
 // It is also possible to set `FZ_VERSION` environment variable.
 var FzVersion = "1.24.9"

--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -113,9 +113,7 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
-	if Quiet {
-		C.go_fitz_silence(f.ctx)
-	}
+	C.go_fitz_silence(f.ctx)
 
 	C.fz_register_document_handlers(f.ctx)
 
@@ -150,9 +148,7 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 		return
 	}
 
-	if Quiet {
-		C.go_fitz_silence(f.ctx)
-	}
+	C.go_fitz_silence(f.ctx)
 
 	C.fz_register_document_handlers(f.ctx)
 

--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -62,6 +62,16 @@ int run_page_contents(fz_context *ctx, fz_page *page, fz_device *dev, fz_matrix 
 
 	return 1;
 }
+
+static void go_fitz_silent_cb(void *user, const char *message) {
+	(void)user;
+	(void)message;
+}
+
+void go_fitz_silence(fz_context *ctx) {
+	fz_set_warning_callback(ctx, go_fitz_silent_cb, NULL);
+	fz_set_error_callback(ctx, go_fitz_silent_cb, NULL);
+}
 */
 import "C"
 
@@ -103,6 +113,10 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
+	if Quiet {
+		C.go_fitz_silence(f.ctx)
+	}
+
 	C.fz_register_document_handlers(f.ctx)
 
 	cfilename := C.CString(filename)
@@ -134,6 +148,10 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 	if f.ctx == nil {
 		err = ErrCreateContext
 		return
+	}
+
+	if Quiet {
+		C.go_fitz_silence(f.ctx)
 	}
 
 	C.fz_register_document_handlers(f.ctx)

--- a/fitz_nocgo.go
+++ b/fitz_nocgo.go
@@ -45,6 +45,10 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
+	if Quiet {
+		applySilence(f.ctx)
+	}
+
 	fzRegisterDocumentHandlers(f.ctx)
 
 	f.doc = fzOpenDocument(f.ctx, filename)
@@ -73,6 +77,10 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 	if f.ctx == nil {
 		err = ErrCreateContext
 		return
+	}
+
+	if Quiet {
+		applySilence(f.ctx)
 	}
 
 	fzRegisterDocumentHandlers(f.ctx)
@@ -567,7 +575,18 @@ var (
 	fzPrintStextPageAsHTML     func(ctx *fzContext, out *fzOutput, page *fzStextPage, id int)
 	fzPrintStextHeaderAsHTML   func(ctx *fzContext, out *fzOutput)
 	fzPrintStextTrailerAsHTML  func(ctx *fzContext, out *fzOutput)
+	fzSetWarningCallback       func(ctx *fzContext, cb uintptr, user *byte)
+	fzSetErrorCallback         func(ctx *fzContext, cb uintptr, user *byte)
+
+	silentCallback uintptr
 )
+
+// applySilence installs no-op warning/error callbacks on the given context,
+// suppressing MuPDF stderr output. See package-level Quiet.
+func applySilence(ctx *fzContext) {
+	fzSetWarningCallback(ctx, silentCallback, nil)
+	fzSetErrorCallback(ctx, silentCallback, nil)
+}
 
 func init() {
 	libmupdf = loadLibrary()
@@ -624,6 +643,10 @@ func init() {
 	purego.RegisterLibFunc(&fzPrintStextPageAsHTML, libmupdf, "fz_print_stext_page_as_html")
 	purego.RegisterLibFunc(&fzPrintStextHeaderAsHTML, libmupdf, "fz_print_stext_header_as_html")
 	purego.RegisterLibFunc(&fzPrintStextTrailerAsHTML, libmupdf, "fz_print_stext_trailer_as_html")
+	purego.RegisterLibFunc(&fzSetWarningCallback, libmupdf, "fz_set_warning_callback")
+	purego.RegisterLibFunc(&fzSetErrorCallback, libmupdf, "fz_set_error_callback")
+
+	silentCallback = purego.NewCallback(func(user *byte, message *byte) {})
 
 	ver := version()
 	if ver != "" {

--- a/fitz_nocgo.go
+++ b/fitz_nocgo.go
@@ -45,9 +45,7 @@ func New(filename string) (f *Document, err error) {
 		return
 	}
 
-	if Quiet {
-		applySilence(f.ctx)
-	}
+	applySilence(f.ctx)
 
 	fzRegisterDocumentHandlers(f.ctx)
 
@@ -79,9 +77,7 @@ func NewFromMemory(b []byte) (f *Document, err error) {
 		return
 	}
 
-	if Quiet {
-		applySilence(f.ctx)
-	}
+	applySilence(f.ctx)
 
 	fzRegisterDocumentHandlers(f.ctx)
 
@@ -582,7 +578,7 @@ var (
 )
 
 // applySilence installs no-op warning/error callbacks on the given context,
-// suppressing MuPDF stderr output. See package-level Quiet.
+// suppressing MuPDF stderr output.
 func applySilence(ctx *fzContext) {
 	fzSetWarningCallback(ctx, silentCallback, nil)
 	fzSetErrorCallback(ctx, silentCallback, nil)

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -318,15 +318,10 @@ type emptyReader struct{}
 
 func (emptyReader) Read([]byte) (int, error) { return 0, io.EOF }
 
-// TestQuiet verifies that enabling fitz.Quiet does not break normal
-// Document creation and text extraction. It cannot reliably assert
-// absence of stderr output without redirecting fd 2, which is both
-// racy and platform-specific; the test simply exercises the code path.
-func TestQuiet(t *testing.T) {
-	prev := fitz.Quiet
-	fitz.Quiet = true
-	defer func() { fitz.Quiet = prev }()
-
+// TestSilencedCallbacks verifies that the unconditional silencing of
+// MuPDF warning/error callbacks does not break normal Document creation
+// and text extraction.
+func TestSilencedCallbacks(t *testing.T) {
 	doc, err := fitz.New(filepath.Join("testdata", "test.pdf"))
 	if err != nil {
 		t.Fatal(err)

--- a/fitz_test.go
+++ b/fitz_test.go
@@ -317,3 +317,23 @@ func TestEmptyBytes(t *testing.T) {
 type emptyReader struct{}
 
 func (emptyReader) Read([]byte) (int, error) { return 0, io.EOF }
+
+// TestQuiet verifies that enabling fitz.Quiet does not break normal
+// Document creation and text extraction. It cannot reliably assert
+// absence of stderr output without redirecting fd 2, which is both
+// racy and platform-specific; the test simply exercises the code path.
+func TestQuiet(t *testing.T) {
+	prev := fitz.Quiet
+	fitz.Quiet = true
+	defer func() { fitz.Quiet = prev }()
+
+	doc, err := fitz.New(filepath.Join("testdata", "test.pdf"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer doc.Close()
+
+	if _, err := doc.Text(0); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Unconditionally silences MuPDF warning and error callbacks on every new context, suppressing stderr noise like `warning: ignoring CMap range ...`. Errors are still surfaced via Go `error` returns.

Closes #132.

### Changes

- **cgo** (`fitz_cgo.go`): static no-op callback + `go_fitz_silence(ctx)` called in `New` and `NewFromMemory`.
- **nocgo** (`fitz_nocgo.go`): single `purego.NewCallback` allocated in `init()`, reused for every context via `applySilence`.
- All 35 tests pass, `go build ./...`, `go vet ./...` clean.