### PR TITLE
Fix capitalization in info:ModDate

### DIFF
--- a/fitz_cgo.go
+++ b/fitz_cgo.go
@@ -557,7 +557,7 @@ func (f *Document) Metadata() map[string]string {
 	data["creator"] = lookup("info:Creator")
 	data["producer"] = lookup("info:Producer")
 	data["creationDate"] = lookup("info:CreationDate")
-	data["modDate"] = lookup("info:modDate")
+	data["modDate"] = lookup("info:ModDate")
 
 	return data
 }

--- a/fitz_nocgo.go
+++ b/fitz_nocgo.go
@@ -475,7 +475,7 @@ func (f *Document) Metadata() map[string]string {
 	data["creator"] = lookup("info:Creator")
 	data["producer"] = lookup("info:Producer")
 	data["creationDate"] = lookup("info:CreationDate")
-	data["modDate"] = lookup("info:modDate")
+	data["modDate"] = lookup("info:ModDate")
 
 	return data
 }


### PR DESCRIPTION
When extracting PDF metadata using `Document.Metadata()`, `data["modDate"]` is always empty.

This is caused by the following line:
```go
data["modDate"] = lookup("info:modDate")
```

`modDate` (with a lowercase `m`) is not recognized by fitz as a valid metadata field.
The correct lookup is:
```go
data["modDate"] = lookup("info:ModDate")
```

This lines up with `FZ_META_INFO_MODIFICATIONDATE`, and makes `Document.Metadata()` return the expected results.